### PR TITLE
ファイル集計時に対象年月以外の行の存在により起こっていた無限ループを修正

### DIFF
--- a/kintai_kadai_main.java
+++ b/kintai_kadai_main.java
@@ -69,23 +69,17 @@ public class Main {
 
                 File file = new File("data.csv");
 
-                try(
-                        FileReader fr = new FileReader(file);
-                        BufferedReader br = new BufferedReader(fr);
-                        ) {
-
-                    String line = br.readLine();
+                try(FileReader fr = new FileReader(file); BufferedReader br = new BufferedReader(fr)) {
+                    String line;
                     Map<String, Integer> totalWorkMinutesMap = new HashMap<>();
                     Map<String, Integer> totalOverWorkMinutesMap = new HashMap<>();
-                    while(line != null){
+                    while((line = br.readLine()) != null){
                         String[] columns = line.split(",");
                         if(!columns[0].startsWith(yearMonth)) {
                             continue;
                         }
                         totalWorkMinutesMap.put(columns[0], Integer.valueOf(columns[3]));
                         totalOverWorkMinutesMap.put(columns[0], Integer.valueOf(columns[4]));
-
-                        line = br.readLine();
                     }
 
                     Set<String> keySet = totalWorkMinutesMap.keySet();


### PR DESCRIPTION
勤務時間の集計時に、対象の年月プレフィックスが見つからなかった場合に、新たな行を読み込まずに `continue` していたため、条件に合致したファイルが入力されると無限ループに陥ってしまっていた。

これを課題テーマとして、そのままリファクタリングしてしまうと、バグごと持ち込むことになってしまうため、この点のみ修正PRを出すことにした。

新しい行の読み込みを、必ずループの先頭で行うように変更することで、無限ループを解消する。